### PR TITLE
Add datetime dummy variable generators

### DIFF
--- a/fclib/fclib/feature_engineering/dummyvar.py
+++ b/fclib/fclib/feature_engineering/dummyvar.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import calendar
 import pandas as pd
 import numpy as np

--- a/fclib/fclib/feature_engineering/dummyvar.py
+++ b/fclib/fclib/feature_engineering/dummyvar.py
@@ -31,7 +31,7 @@ def get_weekofyear_dummies(date):
         date: Datetime Pandas series.
 
     Returns:
-        Dataframe with 53 columns containing dummy variables.
+        Dataframe with 53 columns containing dummy variables. The columns are labelled from 1 to 53.
     """
     full = pd.DataFrame(np.zeros((len(date), 53)), dtype="uint8", columns=pd.RangeIndex(1, 54))
     wk = pd.get_dummies(date.dt.weekofyear)
@@ -47,7 +47,7 @@ def get_dayofyear_dummies(date):
         date: Datetime Pandas series.
 
     Returns:
-        Dataframe with 366 columns containing dummy variables.
+        Dataframe with 366 columns containing dummy variables. The columns are labelled from 1 to 366.
     """
     full = pd.DataFrame(np.zeros((len(date), 366)), dtype="uint8", columns=pd.RangeIndex(1, 367))
     dyr = pd.get_dummies(date.dt.dayofyear)
@@ -63,7 +63,7 @@ def get_day_dummies(date):
         date: Datetime Pandas series.
 
     Returns:
-        Dataframe with 31 columns containing dummy variables.
+        Dataframe with 31 columns containing dummy variables. The columns are labelled from 1 to 31.
     """
     full = pd.DataFrame(np.zeros((len(date), 31)), dtype="uint8", columns=pd.RangeIndex(1, 32))
     day = pd.get_dummies(date.dt.day)
@@ -79,7 +79,7 @@ def get_weekday_dummies(date):
         date: Datetime Pandas series.
 
     Returns:
-        Dataframe with 7 columns containing dummy variables.
+        Dataframe with 7 columns containing dummy variables. The column names are the weekday abbreviations.
     """
     full = pd.DataFrame(np.zeros((len(date), 7)), dtype="uint8", columns=pd.RangeIndex(0, 7))
     wkd = pd.get_dummies(date.dt.weekday)
@@ -96,9 +96,9 @@ def get_quarter_dummies(date):
         date: Datetime Pandas series.
 
     Returns:
-        Dataframe with 4 columns containing dummy variables.
+        Dataframe with 4 columns containing dummy variables. The columns are labelled from 1 to 4.
     """
-    full = pd.DataFrame(np.zeros((len(date), 4)), dtype="uint8", columns=pd.RangeIndex(0, 4))
+    full = pd.DataFrame(np.zeros((len(date), 4)), dtype="uint8", columns=pd.RangeIndex(1, 5))
     qt = pd.get_dummies(date.dt.quarter)
     full[qt.columns] = qt
     return full
@@ -112,7 +112,7 @@ def get_hour_dummies(date):
         date: Datetime Pandas series.
 
     Returns:
-        Dataframe with 24 columns containing dummy variables.
+        Dataframe with 24 columns containing dummy variables. The columns are labelled from 0 to 23.
     """
     full = pd.DataFrame(np.zeros((len(date), 24)), dtype="uint8", columns=pd.RangeIndex(0, 24))
     hr = pd.get_dummies(date.dt.hour)
@@ -128,7 +128,7 @@ def get_minute_dummies(date):
         date: Datetime Pandas series.
 
     Returns:
-        Dataframe with 60 columns containing dummy variables.
+        Dataframe with 60 columns containing dummy variables. The columns are labelled from 0 to 59.
     """
     full = pd.DataFrame(np.zeros((len(date), 60)), dtype="uint8", columns=pd.RangeIndex(0, 60))
     min = pd.get_dummies(date.dt.minute)

--- a/fclib/fclib/feature_engineering/dummyvar.py
+++ b/fclib/fclib/feature_engineering/dummyvar.py
@@ -1,0 +1,133 @@
+import calendar
+import pandas as pd
+import numpy as np
+
+
+def get_month_dummies(date):
+    """
+    Generate matrix of dummy variables for the month of the year.
+
+    Args:
+        date: Datetime Pandas series.
+
+    Returns:
+        Dataframe with 12 columns containing dummy variables. The column names are the month abbreviations.
+    """
+    full = pd.DataFrame(np.zeros((len(date), 12)), dtype="uint8", columns=pd.RangeIndex(1, 13))
+    mon = pd.get_dummies(date.dt.month)
+    full[mon.columns] = mon
+    full.columns = calendar.month_abbr[slice(1, 13)]
+    return full
+
+
+def get_weekofyear_dummies(date):
+    """
+    Generate matrix of dummy variables for the week of the year.
+
+    Args:
+        date: Datetime Pandas series.
+
+    Returns:
+        Dataframe with 53 columns containing dummy variables.
+    """
+    full = pd.DataFrame(np.zeros((len(date), 53)), dtype="uint8", columns=pd.RangeIndex(1, 54))
+    wk = pd.get_dummies(date.dt.weekofyear)
+    full[wk.columns] = wk
+    return full
+
+
+def get_dayofyear_dummies(date):
+    """
+    Generate matrix of dummy variables for the day of the year.
+
+    Args:
+        date: Datetime Pandas series.
+
+    Returns:
+        Dataframe with 366 columns containing dummy variables.
+    """
+    full = pd.DataFrame(np.zeros((len(date), 366)), dtype="uint8", columns=pd.RangeIndex(1, 367))
+    dyr = pd.get_dummies(date.dt.dayofyear)
+    full[dyr.columns] = dyr
+    return full
+
+
+def get_day_dummies(date):
+    """
+    Generate matrix of dummy variables for the day of the month.
+
+    Args:
+        date: Datetime Pandas series.
+
+    Returns:
+        Dataframe with 31 columns containing dummy variables.
+    """
+    full = pd.DataFrame(np.zeros((len(date), 31)), dtype="uint8", columns=pd.RangeIndex(1, 32))
+    day = pd.get_dummies(date.dt.day)
+    full[day.columns] = day
+    return full
+
+
+def get_weekday_dummies(date):
+    """
+    Generate matrix of dummy variables for the day of the week.
+
+    Args:
+        date: Datetime Pandas series.
+
+    Returns:
+        Dataframe with 7 columns containing dummy variables.
+    """
+    full = pd.DataFrame(np.zeros((len(date), 7)), dtype="uint8", columns=pd.RangeIndex(0, 7))
+    wkd = pd.get_dummies(date.dt.weekday)
+    full[wkd.columns] = wkd
+    full.columns = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    return full
+
+
+def get_quarter_dummies(date):
+    """
+    Generate matrix of dummy variables for the quarter of the year.
+
+    Args:
+        date: Datetime Pandas series.
+
+    Returns:
+        Dataframe with 4 columns containing dummy variables.
+    """
+    full = pd.DataFrame(np.zeros((len(date), 4)), dtype="uint8", columns=pd.RangeIndex(0, 4))
+    qt = pd.get_dummies(date.dt.quarter)
+    full[qt.columns] = qt
+    return full
+
+
+def get_hour_dummies(date):
+    """
+    Generate matrix of dummy variables for the hour of the day.
+
+    Args:
+        date: Datetime Pandas series.
+
+    Returns:
+        Dataframe with 24 columns containing dummy variables.
+    """
+    full = pd.DataFrame(np.zeros((len(date), 24)), dtype="uint8", columns=pd.RangeIndex(0, 24))
+    hr = pd.get_dummies(date.dt.hour)
+    full[hr.columns] = hr
+    return full
+
+
+def get_minute_dummies(date):
+    """
+    Generate matrix of dummy variables for the minute of the hour.
+
+    Args:
+        date: Datetime Pandas series.
+
+    Returns:
+        Dataframe with 60 columns containing dummy variables.
+    """
+    full = pd.DataFrame(np.zeros((len(date), 60)), dtype="uint8", columns=pd.RangeIndex(0, 60))
+    min = pd.get_dummies(date.dt.minute)
+    full[min.columns] = min
+    return full

--- a/fclib/fclib/feature_engineering/feature_utils.py
+++ b/fclib/fclib/feature_engineering/feature_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License. 
+# Licensed under the MIT License.
 
 """
 This file contains utility functions for creating features for time
@@ -165,60 +165,6 @@ def day_of_year(date_time_col):
     return date_time_col.dt.dayofyear
 
 
-# def encoded_month_of_year(month_of_year):
-#     """
-#     Create one hot encoding of month of year.
-#     """
-#     month_of_year = pd.get_dummies(month_of_year, prefix="MonthOfYear")
-
-#     return month_of_year
-
-
-# def encoded_day_of_week(day_of_week):
-#     """
-#     Create one hot encoding of day_of_week.
-#     """
-#     day_of_week = pd.get_dummies(day_of_week, prefix="DayOfWeek")
-
-#     return day_of_week
-
-
-# def encoded_day_of_month(day_of_month):
-#     """
-#     Create one hot encoding of day_of_month.
-#     """
-#     day_of_month = pd.get_dummies(day_of_month, prefix="DayOfMonth")
-
-#     return day_of_month
-
-
-# def encoded_day_of_year(day_of_year):
-#     """
-#     Create one hot encoding of day_of_year.
-#     """
-#     day_of_year = pd.get_dummies(day_of_year)
-
-#     return day_of_year
-
-
-# def encoded_hour_of_day(hour_of_day):
-#     """
-#     Create one hot encoding of hour_of_day.
-#     """
-#     hour_of_day = pd.get_dummies(hour_of_day, prefix="HourOfDay")
-
-#     return hour_of_day
-
-
-# def encoded_week_of_year(week_of_year):
-#     """
-#     Create one hot encoding of week_of_year.
-#     """
-#     week_of_year = pd.get_dummies(week_of_year, prefix="WeekOfYear")
-
-#     return week_of_year
-
-
 def normalized_current_year(datetime_col, min_year, max_year):
     """
     Temporal feature indicating the position of the year of a record in the
@@ -255,11 +201,11 @@ def normalized_current_date(datetime_col, min_date, max_date):
     Returns:
         float: the position of the current date in the min_date:max_date range
     """
-    date = datetime_col # .dt.date
-    current_date = (date - min_date) # .apply(lambda x: x.days)
+    date = datetime_col  # .dt.date
+    current_date = date - min_date  # .apply(lambda x: x.days)
 
     if max_date != min_date:
-        current_date = current_date / (max_date - min_date) # .days
+        current_date = current_date / (max_date - min_date)  # .days
     else:
         current_date = pd.Series([0 for x in range(len(datetime_col))])
 

--- a/fclib/tests/test_dummyvar.py
+++ b/fclib/tests/test_dummyvar.py
@@ -25,6 +25,7 @@ def test_get_day_dummies():
     assert len(mat.columns) == 31
     for i in range(len(date)):
         assert mat.iloc[i, col.iloc[i] - 1] == 1
+    assert mat.loc[0, 1] == 1
 
 
 def test_get_dayofyear_dummies():
@@ -33,6 +34,7 @@ def test_get_dayofyear_dummies():
     assert len(mat.columns) == 366
     for i in range(len(date)):
         assert mat.iloc[i, col.iloc[i] - 1] == 1
+    assert mat.loc[0, 1] == 1
 
 
 def test_get_hour_dummies():
@@ -41,6 +43,7 @@ def test_get_hour_dummies():
     assert len(mat.columns) == 24
     for i in range(len(time)):
         assert mat.iloc[i, col.iloc[i]] == 1
+    assert mat.loc[0, 13] == 1
 
 
 def test_get_minute_dummies():
@@ -49,6 +52,7 @@ def test_get_minute_dummies():
     assert len(mat.columns) == 60
     for i in range(len(time)):
         assert mat.iloc[i, col.iloc[i]] == 1
+    assert mat.loc[0, 0] == 1
 
 
 def test_get_month_dummies():
@@ -57,6 +61,7 @@ def test_get_month_dummies():
     assert len(mat.columns) == 12
     for i in range(len(date)):
         assert mat.iloc[i, col.iloc[i] - 1] == 1
+    assert mat.loc[0, "Jan"] == 1
 
 
 def test_get_quarter_dummies():
@@ -65,6 +70,7 @@ def test_get_quarter_dummies():
     assert len(mat.columns) == 4
     for i in range(len(date)):
         assert mat.iloc[i, col.iloc[i] - 1] == 1
+    assert mat.loc[0, 1] == 1
 
 
 def test_get_weekday_dummies():
@@ -73,6 +79,7 @@ def test_get_weekday_dummies():
     assert len(mat.columns) == 7
     for i in range(len(date)):
         assert mat.iloc[i, col.iloc[i]] == 1
+    assert mat.loc[0, "Sat"] == 1
 
 
 def test_get_weekofyear_dummies():
@@ -81,3 +88,4 @@ def test_get_weekofyear_dummies():
     assert len(mat.columns) == 53
     for i in range(len(date)):
         assert mat.iloc[i, col.iloc[i] - 1] == 1
+    assert mat.loc[0, 52] == 1

--- a/fclib/tests/test_dummyvar.py
+++ b/fclib/tests/test_dummyvar.py
@@ -1,0 +1,83 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pandas as pd
+
+from fclib.feature_engineering.dummyvar import (
+    get_day_dummies,
+    get_dayofyear_dummies,
+    get_hour_dummies,
+    get_minute_dummies,
+    get_month_dummies,
+    get_quarter_dummies,
+    get_weekday_dummies,
+    get_weekofyear_dummies,
+)
+
+date = pd.to_datetime(pd.Series(["2000-01-01", "2000-01-02", "2000-01-03"]))
+
+time = pd.to_datetime(pd.Series(["13:00:00", "13:01:00", "13:02:00"]))
+
+
+def test_get_day_dummies():
+    mat = get_day_dummies(date)
+    col = date.dt.day
+    assert len(mat.columns) == 31
+    for i in range(len(date)):
+        assert mat.iloc[i, col.iloc[i] - 1] == 1
+
+
+def test_get_dayofyear_dummies():
+    mat = get_dayofyear_dummies(date)
+    col = date.dt.dayofyear
+    assert len(mat.columns) == 366
+    for i in range(len(date)):
+        assert mat.iloc[i, col.iloc[i] - 1] == 1
+
+
+def test_get_hour_dummies():
+    mat = get_hour_dummies(time)
+    col = time.dt.hour
+    assert len(mat.columns) == 24
+    for i in range(len(time)):
+        assert mat.iloc[i, col.iloc[i]] == 1
+
+
+def test_get_minute_dummies():
+    mat = get_minute_dummies(time)
+    col = time.dt.minute
+    assert len(mat.columns) == 60
+    for i in range(len(time)):
+        assert mat.iloc[i, col.iloc[i]] == 1
+
+
+def test_get_month_dummies():
+    mat = get_month_dummies(date)
+    col = date.dt.month
+    assert len(mat.columns) == 12
+    for i in range(len(date)):
+        assert mat.iloc[i, col.iloc[i] - 1] == 1
+
+
+def test_get_quarter_dummies():
+    mat = get_quarter_dummies(date)
+    col = date.dt.quarter
+    assert len(mat.columns) == 4
+    for i in range(len(date)):
+        assert mat.iloc[i, col.iloc[i] - 1] == 1
+
+
+def test_get_weekday_dummies():
+    mat = get_weekday_dummies(date)
+    col = date.dt.weekday
+    assert len(mat.columns) == 7
+    for i in range(len(date)):
+        assert mat.iloc[i, col.iloc[i]] == 1
+
+
+def test_get_weekofyear_dummies():
+    mat = get_weekofyear_dummies(date)
+    col = date.dt.weekofyear
+    assert len(mat.columns) == 53
+    for i in range(len(date)):
+        assert mat.iloc[i, col.iloc[i] - 1] == 1


### PR DESCRIPTION
### Description
Adds utility functions for generating the dummy variable matrix for a number of common datetime variables: day (of month), day of year, hour, minute, month, quarter, weekday and week (of year). These are based on the Pandas datetime functions, and always return dataframes with a fixed number of columns (unlike `pd.get_dummies`). They can be useful for any model that requires dummy variables based on dates and times.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests.
- [x] I have updated the documentation accordingly.